### PR TITLE
Update version to 0.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.projectempire.lx</groupId>
     <artifactId>empire-lxpackage</artifactId>
-    <version>0.0.4</version>
+    <version>0.0.5</version>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION
This pull request includes a version update in the `pom.xml` file. The version of the `empire-lxpackage` artifact has been incremented from `0.0.4` to `0.0.5` to reflect a new release.